### PR TITLE
Use bool by itself

### DIFF
--- a/src/O4_Airport_Utils.py
+++ b/src/O4_Airport_Utils.py
@@ -372,7 +372,7 @@ def list_airports_and_runways(dico_airports):
 
 ####################################################################################################
 def build_airport_array(tile,dico_airports):
-    airport_array=numpy.zeros((1001,1001),dtype=numpy.bool)
+    airport_array=numpy.zeros((1001,1001),dtype=bool)
     for airport in dico_airports:
         (xmin,ymin,xmax,ymax)=dico_airports[airport]['boundary'].bounds
         x_shift=1500*GEO.m_to_lon(tile.lat) 

--- a/src/O4_DSF_Utils.py
+++ b/src/O4_DSF_Utils.py
@@ -100,7 +100,7 @@ def zone_list_to_ortho_dico(tile):
         # where higher lines have priority over lower ones.
         masks_im=Image.new("L",(4096,4096),'black')
         masks_draw=ImageDraw.Draw(masks_im)
-        airport_array=numpy.zeros((4096,4096),dtype=numpy.bool)
+        airport_array=numpy.zeros((4096,4096),dtype=bool)
         if tile.cover_airports_with_highres in ['True','ICAO']:
             UI.vprint(1,"-> Checking airport locations for upgraded zoomlevel.")
             try:


### PR DESCRIPTION
AttributeError: module 'numpy' has no attribute 'bool'.
np.bool was a deprecated alias for the builtin bool. To avoid this error in existing code, use bool by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use np.bool_ here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?